### PR TITLE
Update BlaCk-Void.zshrc

### DIFF
--- a/BlaCk-Void.zshrc
+++ b/BlaCk-Void.zshrc
@@ -135,6 +135,7 @@ local _OMZ_SOURCES=(
     lib/compfix.zsh
     lib/directories.zsh
     lib/git.zsh
+    lib/functions.zsh
     lib/termsupport.zsh
 
     # Plugins


### PR DESCRIPTION
mac 기본 터미널에서 아래 오류 수정
update_terminalapp_cwd:4: command not found: omz_urlencod

mac 기본터미널일 경우 아래 파일의 update_terminalapp_cwd() 함수가 실행됩니다.
~/.zplugin/plugins/robbyrussell---oh-my-zsh/lib/termsupport.zsh

update_terminalapp_cwd() 함수는 내부에서 omz_urlencode()함수를 실행하는데,
omz_urlencode()함수는 아래의 경로에 있지만 Black-Void.zshrc에서 아래 파일을 읽어들이지 않고 있어서 추가한 내용입니다.
~/.zplugin/plugins/robbyrussell---oh-my-zsh/lib/functions.zsh

ps) 좋은 프로그램 만들어 주셔서 감사합니다. ^^